### PR TITLE
Synopsis & Nomenclature additions to the template

### DIFF
--- a/report_template.tex
+++ b/report_template.tex
@@ -9,6 +9,14 @@
 \subject{CXX XXX}
 \date{\today}
 
+%Nomenclature unit command
+\newcommand{\nomunit}[1]{%
+\renewcommand{\nometryend}{\hspace*{\fill}#1}}
+
+% Create a custom user command or run the following 
+%  makeindex %.nlo -s nomencl.ist -o %.nls
+% execute this command after compiling your file once, then compile a second time to generate a nomenclature table
+
 \begin{document}
 \maketitle
 \makecoverpage
@@ -22,8 +30,9 @@
 \end{center}
 
 \section*{Synopsis}
+\addcontentsline{toc}{section}{Synopysis}%
 This is the synopsis
-
+\setcounter{page}{3}
 \newpage
 \tableofcontents
 \newpage
@@ -45,7 +54,7 @@ Background, problem statement, purpose, method, scope
 \section{Theory}
 Summary of the relevant theory, including ample references. You can refer to citations like~\citep{bruckmanmandersloot} for an inline reference or \citep{bruckmanmandersloot} to get the citation in parentheses. You can also cite multiple authors~\citep{mandersloot,bruckmanmandersloot}
 
-The height $h$ was measured as a function of time $t$.  The relationship between $h$ and $t$ was found to be 
+The height $h$ \nomenclature{h}{Height \nomunit{m}} was measured as a function of time $t$ \nomenclature{t}{time \nomunit{s}}.  The relationship between $h$ and $t$ was found to be 
 \begin{equation}
   \label{eq:commaexample}
   h(t) = h_0 - \lambda t

--- a/upreport.sty
+++ b/upreport.sty
@@ -66,7 +66,7 @@
 %\usepackage{fancyhdr}
 
 % Nomenclature list
-\usepackage{nomencl}
+\usepackage[intoc]{nomencl}
 \makenomenclature % required by nomencl -- used to be \makeglossary
 % For indexing of document
 


### PR DESCRIPTION
I have added the synopsis to the table of contents, and changed the page number to reflect what is shown in section 3.2.1 of the style guide. I have also added examples of how the nomenclature package can be used, and have added a command that allows for the generation of a unit column in the nomenclature list. I also added a brief explanation of how to generate the nomenclature list using makeindex.  Lastly, I added the option to include the nomenclature heading in the table of contents using \usepackage[intoc]{nomencl}.
