### PR TITLE
Update report_template.tex

### DIFF
--- a/report_template.tex
+++ b/report_template.tex
@@ -32,7 +32,6 @@
 \section*{Synopsis}
 \addcontentsline{toc}{section}{Synopysis}%
 This is the synopsis
-\setcounter{page}{3}
 \newpage
 \tableofcontents
 \newpage


### PR DESCRIPTION
Removed hard-code page number for the synopsis section to allow flexibility.

The synopsis page now is now page 1, I'm not sure this agrees with the style guide which seems to show that the title page is page 1, making the synopsis page 3 (2 if the cover page is not included in the count?)
