### PR TITLE
Update report_template.tex

### DIFF
--- a/report_template.tex
+++ b/report_template.tex
@@ -140,8 +140,12 @@ No new information
 \bibliographystyle{chemeng}
 
 \appendix
-
+\renewcommand{\thefigure}{\thesection.\arabic{figure}}
+\renewcommand{\thepage}{\thesection.\arabic{page}}
 \section{First appendix}
+\setcounter{figure}{0}
+\setcounter{page}{1}
+% Renew figure and page counter per Appendix using the commands above
 Include only if necessary. Not a place to dump raw figures or calculations
 
 \end{document}


### PR DESCRIPTION
Renewal of figure numbering to allow figures in the Appendices to be referred to as Figure A.1, Figure A.2, etc.

Renewal of page numbering to allow for Appendices to have page numbers initialised at page A.1 for Appendix A, page B.1 for Appendix B, etc.

The study guide does not make use of the page numbering renewal, this feature is debatable, although the figure number feature does seem like a good addition.
