### PR TITLE
Biblatex changeover

### DIFF
--- a/report_template.tex
+++ b/report_template.tex
@@ -1,8 +1,15 @@
+% arara: pdflatex
+% arara: bibtex
+% arara: makeindex
+% arara: nomencl
+% arara: pdflatex
+% arara: pdflatex
+
 \documentclass[a4paper,12pt]{article}
 %\RequirePackage[l2tabu,orthodox]{nag}
 
 \usepackage{upreport}
-
+\addbibresource{report.bib}
 \title{Sample report}
 \author{Carl Sandrock}
 \studentnumber{1234567}
@@ -11,47 +18,20 @@
 
 %Nomenclature unit command
 \newcommand{\nomunit}[1]{%
-\renewcommand{\nometryend}{\hspace*{\fill}#1}}
+\renewcommand{\nomentryend}{\hspace*{\fill}#1}}
 
 % Create a custom user command or run the following 
 %  makeindex %.nlo -s nomencl.ist -o %.nls
 % execute this command after compiling your file once, then compile a second time to generate a nomenclature table
 
 \begin{document}
-\maketitle
-\makecoverpage
-
-\pagestyle{plain}
-\thispagestyle{plain}
-\pagenumbering{roman}
-
-\begin{center}
-\LARGE\textbf{\thetitle}
-\end{center}
-
-\section*{Synopsis}
-\addcontentsline{toc}{section}{Synopysis}%
-This is the synopsis
-\newpage
-\tableofcontents
-\newpage
-\listoffigures
-\newpage
-\listoftables
-\newpage
-%\chapter*{Nomenclature}
-\printnomenclature
-\newpage
-
-\pagestyle{plain}
-\setcounter{page}{1}
-\pagenumbering{arabic}
+\input{frontmatter}
 
 \section{Introduction}
 Background, problem statement, purpose, method, scope
 
 \section{Theory}
-Summary of the relevant theory, including ample references. You can refer to citations like~\citep{bruckmanmandersloot} for an inline reference or \citep{bruckmanmandersloot} to get the citation in parentheses. You can also cite multiple authors~\citep{mandersloot,bruckmanmandersloot}
+Summary of the relevant theory, including ample references. You can refer to citations like~\textcite{bruckmanmandersloot} for an inline reference or \parencite{bruckmanmandersloot} to get the citation in parentheses. You can also cite multiple authors~\parencite{mandersloot,bruckmanmandersloot}
 
 The height $h$ \nomenclature{h}{Height \nomunit{m}} was measured as a function of time $t$ \nomenclature{t}{time \nomunit{s}}.  The relationship between $h$ and $t$ was found to be 
 \begin{equation}
@@ -88,12 +68,30 @@ Apparatus, planning and methods
 \section{Results and Discussion}
 Supporting evidence, most important results first. Use graphs and tables where possible. Explain the observed correlations between variables.
 
-You may want to use a table like Table~\ref{tab:tabexample}, or figures like Figure~\ref{fig:samplefigure}
+Prefer simple tables like Table~\ref{tab:simpletabexample} or may want to use a
+more complicated table like Table~\ref{tab:tabexample}.
+\begin{table}[htbp]
+  \centering
+  \caption{Example of a simple table}
+  \label{tab:simpletabexample}
+  \begin{tabular}{lll}
+    \toprule
+    Head 1 & Head 2& Head 3 \\
+    \midrule
+    Item 1 & value 1 & Value 2 \\
+    Item 2 & value 1 & Value 2 \\
+    Item 3 & value 1 & Value 2 \\
+    Item 4 & value 1 & Value 2 \\
+    \bottomrule
+  \end{tabular}
+\end{table}
 
 \begin{table}[htbp]
   \centering
-  \caption[Short caption for table of tables]{Example of a table (adapted from \citet{fear})}
+  \caption[Short caption for table of tables]{Example of a complicated table (adapted from \textcite{fear})}
   \label{tab:tabexample}
+  % This minipage is only necessary when you need footnotes. For most tables you
+  % can use the simple format.
   \begin{minipage}{0.5\textwidth}
     \begin{centering}
       \begin{tabular}{@{}llr@{}} \toprule 
@@ -115,9 +113,11 @@ You may want to use a table like Table~\ref{tab:tabexample}, or figures like Fig
   \end{minipage}
 \end{table}
 
+You may also use figures like Figure~\ref{fig:samplefigure}
+
 \begin{figure}[htbp]
   \centering
-  \includegraphics[width=\halfwidth]{samplefigure.pdf}
+  \includegraphics[width=\fullwidth]{samplefigure.pdf}
   \caption[Short caption which will be in the table of figures]{Example of a figure.  Note that the line types are easy to
     distinguish without a colour display.  Include a citation in the caption if the figure is from referred source}
   \label{fig:samplefigure}
@@ -136,9 +136,8 @@ numbers occurs (use \SI{1}{\nano\meter} instead of \SI{1e-9}{\meter}).
 Main findings
 No new information
 
-\bibliography{report}
-\bibliographystyle{chemeng}
 
+\printbibliography
 \appendix
 \renewcommand{\thefigure}{\thesection.\arabic{figure}}
 \renewcommand{\thepage}{\thesection.\arabic{page}}

--- a/upreport.sty
+++ b/upreport.sty
@@ -8,21 +8,33 @@
 
 % Font encoding and changing
 %\usepackage{pandora} % optima pandora times
+
+% count the totals for figures and tables in order to show the list of figures
+% and tables only if they are there.
+\usepackage[figure,table]{totalcount}
+
+% Use ISO date format
 \usepackage[iso,english]{isodate}
 
+% spacing
 \usepackage{setspace}
   \onehalfspacing
 
+% Page margins
 \usepackage[margin=1in]{geometry}
 
-\usepackage[longnamesfirst]{natbib}
-  \bibpunct[: ]{(}{)}{;}{a}{,}{,} 
+%allow inverted commas in the bibliography
+\usepackage{csquotes}
 
+% bibliographical typesetting
+\usepackage[style=authoryear, backend=biber, natbib=true]{biblatex}
+%natbib=true allows the natbib \cite syntax to be used, this should be used for existing files only
+% \parencite replaces \citep
+% \textcite replaces \citet
+% for bib files: Journaltitle replaces Journal, Location replaces Address
+
+% Graphics
 \usepackage{graphicx}
-% Typeset numbers with fancynum with spaces (thinspaces) for thousands seperators 
-% and commas for decimals (french)
-\usepackage[french, thinspaces]{fancynum}
-%\usepackage[english, tight]{fancynum}
 
 % Typeset units correctly.  Default tight spacing inserts halfword
 % space between number and unit.  Use loose for full word.
@@ -30,7 +42,6 @@
 
 % Advanced mathematics
 \usepackage{amsmath}
-% \usepackage{amssymb}
 
 \usepackage{color}
 
@@ -55,6 +66,7 @@
 % For listing of code in the document
 \usepackage{listings}
 
+% For tables which go to a next page
 \usepackage{longtable}
 
 % For nicer table rules 
@@ -63,13 +75,12 @@
 % Set the length of space above \toprule (to stop the table head from colliding with the table):
 \setlength{\abovetopsep}{1em}
 
-%\usepackage{fancyhdr}
-
 % Nomenclature list
 \usepackage[intoc]{nomencl}
-\makenomenclature % required by nomencl -- used to be \makeglossary
-% For indexing of document
+% required by nomencl -- used to be \makeglossary
+\makenomenclature 
 
+% For indexing of document
 \usepackage{makeidx}
 \makeindex % required by makeidx
 
@@ -82,13 +93,13 @@
 % Define a default graphics path as graph
 %\graphicspath{{graph/}}
 
-% commands 
+% reserved commands for defining title page variables
 \newcommand*{\subject}[1]{\gdef\@subject{#1}}
 \newcommand*{\studentnumber}[1]{\gdef\@studentnumber{#1}}
 
-%       graphics
-%   Use these widths for full and halfwidth figures.  
-%       Renew them in your document to change them
+% graphics
+% Use these widths for full and halfwidth figures.  
+% Renew them in your document to change them
 \newcommand{\fullwidth}{0.8\textwidth}
 \newcommand{\halfwidth}{0.4\textwidth}
 


### PR DESCRIPTION
Here is a first attempt at a Biblatex changeover. Build options within the TeX environment need to be updated to use Biber as the bibliogry compiler rather than BibTeX. It is recommended to clean all auxiliary files to allow Biber a clean start. 

There is no more need for the chemeng.bst file, and the .bib file should run after a fresh compilation sequence.  See biblatex documentation for .bib keys and required fields. Main addition above BibTeX is the Patent and Thesis fields that reference relevant fields.

\citep -> \parencite
\citet -> \textcite
\cite - > \autocite

Next pull request (nearer to next CSC421 submission) should contain any customisation to the author-year style to suite the style guide.
