### PR TITLE
Bibliopgraphy update

### DIFF
--- a/upreport.sty
+++ b/upreport.sty
@@ -36,8 +36,18 @@
 
 \setlength\bibitemsep{\baselineskip}
 %Adds parapgraph spacing between references in the reference list
-\AtEveryCitekey{\ifciteseen{}{\defcounter{maxnames}{99}}}
+\AtEveryCitekey{\ifciteseen{}{\defcounter{maxnames}{3}}}
 %Fixes first time citations to full author list with all further citations in et. al. form
+\renewcommand*{\finalnamedelim}{%
+	\ifnumgreater{\value{liststop}}{2}{\finalandcomma}{}%
+	\addcomma\addspace\&\space}
+%Replaces all "and" used with "&" in the citations and the bibliography
+\AtBeginBibliography{%
+	\renewcommand*{\finalnamedelim}{%
+		\ifnumgreater{\value{liststop}}{2}{\finalandcomma}{}%
+		\addspace\bibstring{and}\space}%
+}
+%Replaces all "&" uses with "and" in the bibliography only
 
 % Graphics
 \usepackage{graphicx}


### PR DESCRIPTION
The previous commit is in error of the style guide in the following
ways:
The citations use "and" before the last author in the list instead of the prescribed "&".
The citation of more than 3 authors does not shorten to et al format but rather displays all the authors in the first citation

Fixed both of these errors, although the code fix for the "and" instead of "&" is not pretty but it does the job. The ampersand is replaced into the "and" position of both the citation and bibliograpy and then the "and" is reinstated in the bibliograpy.

 This fix is implemeted in this way as I cannot find a command structure that alters the citations in the same manner as \AtBeginBibliograpy does for the bibliography section.
