### PR TITLE
Biblatex config file and code cleanup

### DIFF
--- a/biblatex.cfg
+++ b/biblatex.cfg
@@ -1,0 +1,77 @@
+\ProvidesFile{biblatex.cfg}
+
+% Put your definitions here.
+\DeclareBibliographyDriver{patent}{%
+	\usebibmacro{bibindex}%
+	\usebibmacro{begentry}%
+	\usebibmacro{author}%
+	\setunit{\printdelim{nametitledelim}}\newblock
+	\usebibmacro{title}%
+	\newunit
+	\printlist{language}%
+	\newunit\newblock
+	\usebibmacro{byauthor}%
+	\newunit\newblock
+	\printfield{type}%
+	\setunit*{\addspace}%
+	\newunit\newblock
+	\setunit*{\addcomma\addspace}%
+	\printtext{\addcomma\addspace \mkbibitalic{\printfield{number}}}
+%	\printfield{number}%
+	\newunit\newblock
+	\setunit*{\addcomma\addspace}%
+	\ifnameundef{holder}
+	{}
+	{\printtext{assigned to }%
+	\usebibmacro{byholder}}%
+	\newunit\newblock
+	\setunit*{\addcomma\addspace}%
+	\iflistundef{location}
+	{}
+	{\setunit*{\addcomma\addspace}
+			\printlist[][-\value{listtotal}]{location}}%
+	\newunit\newblock
+	\printfield{note}%
+	\newunit\newblock
+	\usebibmacro{date}%
+	\newunit\newblock
+	\usebibmacro{doi+eprint+url}%
+	\newunit\newblock
+	\usebibmacro{addendum+pubstate}%
+	\setunit{\bibpagerefpunct}\newblock
+	\usebibmacro{pageref}%
+	\newunit\newblock
+	\iftoggle{bbx:related}
+	{\usebibmacro{related:init}%
+		\usebibmacro{related}}
+	{}%
+	\usebibmacro{finentry}}
+
+
+\DeclareNameAlias{sortname}{last-first}
+
+\DeclareFieldFormat[article]{journaltitle}{\mkbibitalic{#1}\addcomma}
+
+\DeclareFieldFormat[book]{title}{\mkbibitalic{#1}\addcomma}
+
+\DeclareFieldFormat[article, booklet]{title}{\mkbibquote{#1}\addcomma}
+
+\DeclareDelimFormat{finalnamedelim}{\addspace\&\addspace}
+
+\DeclareFieldFormat[article]{pages}{#1}
+	
+\AtBeginBibliography{%
+	\DeclareDelimFormat{finalnamedelim}{\addspace\bibstring{and}\addspace}
+}
+
+\renewcommand*{\newunitpunct}{\space}
+
+\renewbibmacro{in:}{}
+
+\AtEveryCitekey{\ifciteseen{}{\defcounter{maxnames}{3}}}
+
+%\DeclareDelimFormat{bibinitdelim}{\addcomma}
+
+%\renewcommand{\bibinitperiod}{}
+
+\endinput

--- a/upreport.sty
+++ b/upreport.sty
@@ -23,31 +23,21 @@
 % Page margins
 \usepackage[margin=1in]{geometry}
 
-%allow inverted commas in the bibliography
+% Allow inverted commas in the bibliography
 \usepackage{csquotes}
 
 % bibliographical typesetting
-\usepackage[style=authoryear, backend=biber, maxbibnames=99, citetracker=true, maxcitenames=1, natbib=true]{biblatex}
-
-%natbib=true allows the natbib \cite syntax to be used, this should be used for existing files only
+\usepackage[style=authoryear, dashed=false, backend=biber, maxbibnames=99,
+			 citetracker=true, maxcitenames=2, natbib=true, giveninits=true, terseinits=true]{biblatex}
+% natbib=true allows the natbib \cite syntax to be used, this should be used for existing files only
 % \parencite replaces \citep
 % \textcite replaces \citet
 % for bib files: Journaltitle replaces Journal, Location replaces Address
 
 \setlength\bibitemsep{\baselineskip}
-%Adds parapgraph spacing between references in the reference list
-\AtEveryCitekey{\ifciteseen{}{\defcounter{maxnames}{3}}}
-%Fixes first time citations to full author list with all further citations in et. al. form
-\renewcommand*{\finalnamedelim}{%
-	\ifnumgreater{\value{liststop}}{2}{\finalandcomma}{}%
-	\addcomma\addspace\&\space}
-%Replaces all "and" used with "&" in the citations and the bibliography
-\AtBeginBibliography{%
-	\renewcommand*{\finalnamedelim}{%
-		\ifnumgreater{\value{liststop}}{2}{\finalandcomma}{}%
-		\addspace\bibstring{and}\space}%
-}
-%Replaces all "&" uses with "and" in the bibliography only
+% Adds parapgraph spacing between references in the reference list
+\setlength{\bibhang}{0in}
+% Removes the paragraph indent in bibliography entries 
 
 % Graphics
 \usepackage{graphicx}


### PR DESCRIPTION
All customisation to the default author-year biblatex style has been
moved to the configuration file "biblatex.cfg". The name of the file
must remain as it is and it must have the same path as the tex file
being created. This is because biblatex calls the config file after
including the specified style and before compilation of the
bibliography.

The config file contains an edited version of the patent driver, as well
as customisation of macros and bibliography settings. Comments can be
included if explanation of the customisation will add value?

As far as cleanup is concerned, predefined customisation tools exist in
biblatex (custom versions of \renewcommand etc.) and were implemented
where possible.
