### PR TITLE
Subcaption example, addressing requested changes

### DIFF
--- a/report_template.tex
+++ b/report_template.tex
@@ -125,7 +125,7 @@ comes from the siunitx package.
 
 You may also use figures like Figure~\ref{fig:samplefigure}
 
-\begin{figure}[htbp]
+\begin{figure}[H]
   \centering
   % notice we specified the size of the figure in the Python file
   \includegraphics{samplefigure.pdf}
@@ -134,39 +134,36 @@ You may also use figures like Figure~\ref{fig:samplefigure}
   \label{fig:samplefigure}
 \end{figure}
 
-If you have multiple figures that need grouping together, then you may use figures like Figure~\ref{fig:subcaptionfigure}, and each subfigure can be referenced as Figure~\ref{fig:1b}
+If you have multiple figures that need grouping together, then you may use figures like Figure~\ref{fig:subcaptionfigure}, and each subfigure can be referenced as Figure~\ref{fig:1b}. It is important to be aware that using subfigures inside \LaTeX will alter the scaling of the image, including the fontsizes, and therefore this should be accounted for while producing the graphs.
 
-\begin{figure}
-	\begin{subfigure}[b]{.33\textwidth}
-		\centering\includegraphics[width=\textwidth]{modelfigure_0.pdf}
-		\caption{noise factor = 1.0}\label{fig:1a}
+\begin{figure}[H]
+	\begin{subfigure}[b]{.5\textwidth}
+		\centering\includegraphics[width=\textwidth]{modelfigure_1p0.pdf}
+		\caption{Noise factor = 1.0}\label{fig:1a}
 	\end{subfigure}\hfill
-	\begin{subfigure}[b]{.33\textwidth}
-		\centering\includegraphics[width=\textwidth]{modelfigure_1.pdf}
-		\caption{noise factor = 10}\label{fig:1b}
+	\begin{subfigure}[b]{.5\textwidth}
+		\centering\includegraphics[width=\textwidth]{differentialfigure_1p0.pdf}
+		\caption{Noise factor = 1.0}\label{fig:1b}
 	\end{subfigure}\hfill
-	\begin{subfigure}[b]{.33\textwidth}
-		\centering\includegraphics[width=\textwidth]{modelfigure_2.pdf}
-		\caption{noise factor = 100}\label{fig:1c}
+	\begin{subfigure}[b]{.5\textwidth}
+		\centering\includegraphics[width=\textwidth]{modelfigure_10.pdf}
+		\caption{Noise factor = 10}\label{fig:1c}
 	\end{subfigure}\hfill
-	\begin{subfigure}[b]{.33\textwidth}
-		\centering\includegraphics[width=\textwidth]{differentialfigure_0.pdf}
-		\caption{noise factor = 1.0}\label{fig:1d}
+	\begin{subfigure}[b]{.5\textwidth}
+		\centering\includegraphics[width=\textwidth]{differentialfigure_10.pdf}
+		\caption{Noise factor = 10}\label{fig:1d}
 	\end{subfigure}\hfill
-	\begin{subfigure}[b]{.33\textwidth}
-		\centering\includegraphics[width=\textwidth]{differentialfigure_1.pdf}
-		\caption{noise factor = 10}\label{fig:1e}
+	\begin{subfigure}[b]{.5\textwidth}
+		\centering\includegraphics[width=\textwidth]{modelfigure_100.pdf}
+		\caption{Noise factor = 100}\label{fig:1e}
 	\end{subfigure}\hfill
-	\begin{subfigure}[b]{.33\textwidth}
-		\centering\includegraphics[width=\textwidth]{differentialfigure_2.pdf}
-		\caption{noise factor = 100}\label{fig:1f}
+	\begin{subfigure}[b]{.5\textwidth}
+		\centering\includegraphics[width=\textwidth]{differentialfigure_100.pdf}
+		\caption{Noise factor = 100}\label{fig:1f}
 	\end{subfigure}
 	\caption[Short caption which will be in the table of figures]{Example of a figure that contains multiple subfigures.  For more options on using subfigures and more complicated subcaptions, see the package documentation at \url{https://gitlab.com/axelsommerfeldt/caption} To update this figure, run samplefigure.py and recompile the document.}
 	\label{fig:subcaptionfigure}
 \end{figure}
-\end{document}
-
-
 
 
 

--- a/report_template.tex
+++ b/report_template.tex
@@ -134,6 +134,43 @@ You may also use figures like Figure~\ref{fig:samplefigure}
   \label{fig:samplefigure}
 \end{figure}
 
+If you have multiple figures that need grouping together, then you may use figures like Figure~\ref{fig:subcaptionfigure}, and each subfigure can be referenced as Figure~\ref{fig:1b}
+
+\begin{figure}
+	\begin{subfigure}[b]{.33\textwidth}
+		\centering\includegraphics[width=\textwidth]{modelfigure_0.pdf}
+		\caption{noise factor = 1.0}\label{fig:1a}
+	\end{subfigure}\hfill
+	\begin{subfigure}[b]{.33\textwidth}
+		\centering\includegraphics[width=\textwidth]{modelfigure_1.pdf}
+		\caption{noise factor = 10}\label{fig:1b}
+	\end{subfigure}\hfill
+	\begin{subfigure}[b]{.33\textwidth}
+		\centering\includegraphics[width=\textwidth]{modelfigure_2.pdf}
+		\caption{noise factor = 100}\label{fig:1c}
+	\end{subfigure}\hfill
+	\begin{subfigure}[b]{.33\textwidth}
+		\centering\includegraphics[width=\textwidth]{differentialfigure_0.pdf}
+		\caption{noise factor = 1.0}\label{fig:1d}
+	\end{subfigure}\hfill
+	\begin{subfigure}[b]{.33\textwidth}
+		\centering\includegraphics[width=\textwidth]{differentialfigure_1.pdf}
+		\caption{noise factor = 10}\label{fig:1e}
+	\end{subfigure}\hfill
+	\begin{subfigure}[b]{.33\textwidth}
+		\centering\includegraphics[width=\textwidth]{differentialfigure_2.pdf}
+		\caption{noise factor = 100}\label{fig:1f}
+	\end{subfigure}
+	\caption[Short caption which will be in the table of figures]{Example of a figure that contains multiple subfigures.  For more options on using subfigures and more complicated subcaptions, see the package documentation at \url{https://gitlab.com/axelsommerfeldt/caption} To update this figure, run samplefigure.py and recompile the document.}
+	\label{fig:subcaptionfigure}
+\end{figure}
+\end{document}
+
+
+
+
+
+
 Numbers are shown with a decimal point, spaces between thousands and $\times 10^x$ notation rather than computer notation (\num{12345.12345e-12}).
 
 SI units should be favoured except where conversion would be

--- a/samplefigure.py
+++ b/samplefigure.py
@@ -5,7 +5,66 @@ import numpy
 # https://matplotlib.org/users/usetex.html
 from matplotlib import rc
 rc('text', usetex=True)
-rc('font', family='serif')#, size=12)
+rc('font', family='serif', size=12)
+
+
+def plotmodel(noise_factor, plot_type, filename, label_size, *args, **kwargs):
+    """plots the function argument Y against the x linspace on the figure axis
+    specified
+
+    Arguments:
+        noise_factor: the factor of noise applied to the model to generate the
+        data
+
+        plot_type:
+            "height" sets the graph with labels for Height vs time
+            "velocity" sets the graph with labels for Velocity vs time
+        filename: must contain the filename, a set of empty braces for noise
+        factor encoding, and the file type extension in a string,
+        "examplename{}.pdf")
+        label_size: the font size of the X and Y axis, used for scaling fonts
+        up when using subfigures
+    """
+    fig, ax = plt.subplots(1, 1, figsize=(5, 4))
+
+    if plot_type == "height":
+        ax.plot(x, modelA, 'k-', label='Model A')
+        ax.plot(x, modelB, 'k--', label='Model B')
+        ax.plot(x, ydata, 'b.', label='Experimental')
+    elif plot_type == "velocity":
+        ax.plot(x[:-1], diffA/dx, 'k-', label='Model A')
+        ax.plot(x[:-1], diffB/dx, 'k--', label='Model B')
+        ax.plot(x[:-1], ydiff/dx, 'b.', label='Experimental')
+    else:
+        raise ValueError("Please enter a valid plot type")
+
+    set_axis_style(ax, plot_type, label_size)
+    plt.savefig((filename).format(str(noise_factor).replace('.', 'p')))
+
+
+def set_axis_style(ax, plot_type, label_size, *args, **kwargs):
+    """Sets the decoration for all the figures in this file.
+
+    Arguments:
+
+        ax: figure axis to apply changes to
+        plot_type:
+        "height" sets the graph with labels corresponding to Height vs time
+        "velocity" sets the graph with labels corresponding to Velocity vs time
+    """
+    if plot_type == "height":
+        ax.set_xlabel('Time / s', fontsize=label_size)
+        ax.set_ylabel('Height / m', fontsize=label_size)
+    elif plot_type == "velocity":
+        ax.set_xlabel('Time / s', fontsize=label_size)
+        ax.set_ylabel(r'Velocity /$m\cdot s^{_1}$', fontsize=label_size)
+    else:
+        raise ValueError("Please enter a valid plot type")
+
+    # the legend starts to take over the graph when subfigures are used
+    ax.legend(fontsize=label_size-2)
+    plt.tight_layout()
+
 
 x = numpy.linspace(0, 10)
 modelA = 100 - x**2
@@ -18,36 +77,23 @@ plt.plot(x, modelB, 'k--', label='Model B')
 plt.plot(x, ydata, 'b.', label='Experimental')
 plt.xlabel('Time / s')
 plt.ylabel('Height / m')
-plt.legend()
+plt.legend(fontsize=12)
 # This ensures the bounding box is correct. If we don't call tight_layout
 # sometimes elements get cut off on the edges.
 plt.tight_layout()
 plt.savefig('samplefigure.pdf')
 
-#Lets investigate the effect of noise on our Model "A" and it's derivative
-for index, value  in enumerate([1.0, 10, 100]):
+# Lets investigate the effect of noise on our Model "A" and it's derivative
+# For-loop structures are very useful for this type of sensitivty analysis
+# However, we can create a function to do most of this for us with ease
+# The functions are plotmodel() and set_axis_style() as above
+
+diffA = numpy.diff(modelA)
+diffB = numpy.diff(modelB)
+dx = x[1]-x[0]
+
+for index, value in enumerate([1.0, 10, 100]):
     ydata = modelA + numpy.random.randn(len(x))*value
-    diffA = numpy.diff(modelA)
     ydiff = numpy.diff(ydata)
-    dx = x[1]-x[0]
-    
-    plt.figure(figsize=(5, 4))  # note figure size in inches
-    plt.plot(x, modelA, 'k-', label='Model A')
-    plt.plot(x, modelB, 'k--', label='Model B')
-    plt.plot(x, ydata, 'b.', label='Experimental')
-    plt.xlabel('Time / s')
-    plt.ylabel('Height / m')
-    plt.legend()
-    plt.tight_layout()
-    plt.savefig(('modelfigure_{}.pdf').format(index))
-    
-    plt.figure(figsize=(5, 4))  # note figure size in inches
-    plt.plot(x[:-1], diffA/dx, 'k-', label='Model A time differential ')
-    plt.plot(x[:-1], ydiff/dx, 'b.', label='Experimental time differential ')
-    plt.xlabel('Time / s')
-    plt.ylabel(r'Velocity /$m\cdot s^{_1}$')
-    plt.legend()
-    # This ensures the bounding box is correct. If we don't call tight_layout
-    # sometimes elements get cut off on the edges.
-    plt.tight_layout()
-    plt.savefig(('differentialfigure_{}.pdf').format(index))
+    plotmodel(value, "height", "modelfigure_{}.pdf", 14)
+    plotmodel(value, "velocity", "differentialfigure_{}.pdf", 14)

--- a/samplefigure.py
+++ b/samplefigure.py
@@ -23,3 +23,31 @@ plt.legend()
 # sometimes elements get cut off on the edges.
 plt.tight_layout()
 plt.savefig('samplefigure.pdf')
+
+#Lets investigate the effect of noise on our Model "A" and it's derivative
+for index, value  in enumerate([1.0, 10, 100]):
+    ydata = modelA + numpy.random.randn(len(x))*value
+    diffA = numpy.diff(modelA)
+    ydiff = numpy.diff(ydata)
+    dx = x[1]-x[0]
+    
+    plt.figure(figsize=(5, 4))  # note figure size in inches
+    plt.plot(x, modelA, 'k-', label='Model A')
+    plt.plot(x, modelB, 'k--', label='Model B')
+    plt.plot(x, ydata, 'b.', label='Experimental')
+    plt.xlabel('Time / s')
+    plt.ylabel('Height / m')
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig(('modelfigure_{}.pdf').format(index))
+    
+    plt.figure(figsize=(5, 4))  # note figure size in inches
+    plt.plot(x[:-1], diffA/dx, 'k-', label='Model A time differential ')
+    plt.plot(x[:-1], ydiff/dx, 'b.', label='Experimental time differential ')
+    plt.xlabel('Time / s')
+    plt.ylabel(r'Velocity /$m\cdot s^{_1}$')
+    plt.legend()
+    # This ensures the bounding box is correct. If we don't call tight_layout
+    # sometimes elements get cut off on the edges.
+    plt.tight_layout()
+    plt.savefig(('differentialfigure_{}.pdf').format(index))


### PR DESCRIPTION
The samplefigure.py has been overhauled, I have left the original figure generation portion of the script as it is to allow those reading to see a "before and after" for a single figure and a collection of figures.

I modified the subfigure display from a shape of (2, 3) to a shape of (3, 2) to reduce the effect of subfigure font scaling, and to prevent the legends of each figure from oversizing the figure.